### PR TITLE
Refactor API surface and include image metadata

### DIFF
--- a/src/Bonsai.Emergent/Bonsai.Emergent.csproj
+++ b/src/Bonsai.Emergent/Bonsai.Emergent.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Bonsai Library containing modules for acquiring images from Emergent Vision cameras. eSDK version 2.62.02 is required.</Description>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
 
@@ -11,7 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\Externals\EmergentCameraDotNet.dll" PackagePath="lib\net481" />
+    <Content Include="Bonsai.Emergent.props" PackagePath="build\net481" />
+    <Content Include="..\Externals\EmergentCameraDotNet.dll" PackagePath="build\net481\bin\x64" />
     <Reference Include="EmergentCameraDotNet">
       <HintPath>..\Externals\EmergentCameraDotNet.dll</HintPath>
     </Reference>

--- a/src/Bonsai.Emergent/Bonsai.Emergent.props
+++ b/src/Bonsai.Emergent/Bonsai.Emergent.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup Condition="'$(Platform.ToLower())' == 'x64' Or '$(Platform.ToLower())' == 'anycpu'">
+    <Reference Include="EmergentCameraDotNet">
+      <HintPath>$(MSBuildThisFileDirectory)bin\x64\EmergentCameraDotNet.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/src/Bonsai.Emergent/EmergentDataFrame.cs
+++ b/src/Bonsai.Emergent/EmergentDataFrame.cs
@@ -1,0 +1,25 @@
+﻿using OpenCV.Net;
+
+namespace Bonsai.Emergent
+{
+    /// <summary>
+    /// Represents a data object containing a decoded video frame and the metadata object
+    /// which contains additional information about the image.
+    /// </summary>
+    /// <param name="image">The decoded video frame.</param>
+    /// <param name="metadata">
+    /// The metadata object which contains additional information about the image.
+    /// </param>
+    public class EmergentDataFrame(IplImage image, ImageMetadata metadata)
+    {
+        /// <summary>
+        /// Gets the decoded video frame.
+        /// </summary>
+        public IplImage Image { get; } = image;
+
+        /// <summary>
+        /// Gets the metadata object which contains additional information about the image.
+        /// </summary>
+        public ImageMetadata Metadata { get; } = metadata;
+    }
+}

--- a/src/Bonsai.Emergent/ImageMetadata.cs
+++ b/src/Bonsai.Emergent/ImageMetadata.cs
@@ -1,0 +1,39 @@
+﻿using Emergent;
+
+namespace Bonsai.Emergent
+{
+    /// <summary>
+    /// Represents additional information about an image decoded from an Emergent Vision camera.
+    /// </summary>
+    public class ImageMetadata
+    {
+        internal ImageMetadata(CEmergentFrameDotNet frame)
+        {
+            NanoSeconds = frame.NanoSeconds;
+            Timestamp = frame.Timestamp;
+            FrameId = frame.FrameId;
+            PixelFormat = (PixelFormat)frame.PixelFormat;
+        }
+
+        /// <summary>
+        /// Gets the precise timestamp in nanoseconds for frames using Myri sync NIC and IRIGB.
+        /// </summary>
+        public ulong NanoSeconds { get; }
+
+        /// <summary>
+        /// Gets the GigE Vision timestamp. If the camera is in precision time protocol (PTP) mode,
+        /// this is the PTP clock of the camera.
+        /// </summary>
+        public ulong Timestamp { get; }
+
+        /// <summary>
+        /// Gets the 16-bit block identifier from the GigE Vision Streaming Protocol.
+        /// </summary>
+        public ushort FrameId { get; }
+
+        /// <summary>
+        /// Gets the pixel format of the decoded image data.
+        /// </summary>
+        public PixelFormat PixelFormat { get; }
+    }
+}

--- a/src/Bonsai.Emergent/PixelFormat.cs
+++ b/src/Bonsai.Emergent/PixelFormat.cs
@@ -135,32 +135,32 @@ namespace Bonsai.Emergent
         /// <summary>
         /// Color red, green, blue 8-bit channels per pixel.
         /// </summary>
-        Rgb8 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_RGB8,
+        RGB8 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_RGB8,
 
         /// <summary>
         /// Color red, green, blue 10-bit channels per pixel.
         /// </summary>
-        Rgb10 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_RGB10,
+        RGB10 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_RGB10,
 
         /// <summary>
         /// Color red, green, blue 12-bit channels per pixel.
         /// </summary>
-        Rgb12 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_RGB12,
+        RGB12 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_RGB12,
 
         /// <summary>
         /// Color blue, green, red 8-bit channels per pixel.
         /// </summary>
-        Bgr8 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_BGR8,
+        BGR8 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_BGR8,
 
         /// <summary>
         /// Color blue, green, red 10-bit channels per pixel.
         /// </summary>
-        Bgr10 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_BGR10,
+        BGR10 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_BGR10,
 
         /// <summary>
         /// Color blue, green, red 12-bit channels per pixel.
         /// </summary>
-        Bgr12 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_BGR12,
+        BGR12 = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_BGR12,
 
         /// <summary>
         /// YUV 411 pixel format packed (no padding bits).
@@ -169,7 +169,7 @@ namespace Bonsai.Emergent
         /// For every four pixels, the Y component is fully sampled for all, but the U and V
         /// components are sampled once and shared across these four pixels.
         /// </remarks>
-        Yuv411Packed = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_YUV411_PACKED,
+        YUV411Packed = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_YUV411_PACKED,
 
         /// <summary>
         /// YUV 422 pixel format packed (no padding bits).
@@ -178,12 +178,12 @@ namespace Bonsai.Emergent
         /// For every two pixels, the Y component is fully sampled for both, but the U and V
         /// components are sampled once and shared across these two pixels.
         /// </remarks>
-        Yuv422Packed = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_YUV422_PACKED,
+        YUV422Packed = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_YUV422_PACKED,
 
         /// <summary>
         /// YUV 444 pixel format packed (no padding bits). The Y, U, and V components are fully
         /// sampled for every pixel.
         /// </summary>
-        Yuv444Packed = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_YUV444_PACKED
+        YUV444Packed = CEmergentFrameDotNet.EPixelFormat.EGVSP_PIX_YUV444_PACKED
     }
 }

--- a/src/Bonsai.Emergent/Properties/AssemblyInfo.cs
+++ b/src/Bonsai.Emergent/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Bonsai.Emergent", "evt")]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Video")]

--- a/src/Bonsai.Emergent/SerialNumberConverter.cs
+++ b/src/Bonsai.Emergent/SerialNumberConverter.cs
@@ -14,7 +14,7 @@ namespace Bonsai.Emergent
 
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            List<CGigEVisionDeviceInfoDotNet> deviceInfoList = new List<CGigEVisionDeviceInfoDotNet>();
+            var deviceInfoList = new List<CGigEVisionDeviceInfoDotNet>();
             CEmergentCameraDotNet.ListDevices(deviceInfoList);
 
             return new StandardValuesCollection(deviceInfoList.Select(x => x.SerialNumber).ToList());


### PR DESCRIPTION
This PR updates the API surface to include image metadata, allow configuring the maximum number of preallocated frames, and picking up the first detected camera if no serial number is specified.

PixelFormat names must be preserved for driver compatibility and a runtime identifier is assigned to match the RID of managed component dependencies.

Finally, the package namespace icon and default XML prefix is declared.