### PR TITLE
Allow manual deployment of documentation website

### DIFF
--- a/.github/workflows/Bonsai.Emergent.yml
+++ b/.github/workflows/Bonsai.Emergent.yml
@@ -20,6 +20,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish-documentation:
+        description: "Publish documentation to GitHub Pages?"
+        default: "false"
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -314,6 +318,7 @@ jobs:
     if: |
       !cancelled() && !failure() && needs.build-documentation.result == 'success'
       && (github.event_name == 'release'
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-documentation == 'true')
         || (vars.CONTINUOUS_DOCUMENTATION && github.event_name != 'pull_request')
       )
     steps:
@@ -340,5 +345,4 @@ jobs:
       # ----------------------------------------------------------------------- Publish to GitHub Pages
       - name: Publish to GitHub Pages
         id: publish
-        if: github.event_name == 'release' || github.event.repository.fork
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
A new input is added to workflow dispatch to allow publishing the documentation website outside of a release.

In general we do want to align publishing to releases, except for the most common case where we realize there is a problem with the docs immediately after going public, in which case it is easier to just fix the problem and retrigger publishing the website.