### PR TITLE
Ensure package requires license acceptance

### DIFF
--- a/build/Package.props
+++ b/build/Package.props
@@ -5,5 +5,7 @@
 
     <Authors>Bonsai Foundation</Authors>
     <Copyright>Copyright © Bonsai Foundation CIC and Contributors</Copyright>
+
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is to ensure compliance with our development guidelines for packages with custom license terms.